### PR TITLE
Fix crash at exit by allocating QObjects on the heap

### DIFF
--- a/src/model/badgecontainer.cpp
+++ b/src/model/badgecontainer.cpp
@@ -1,14 +1,6 @@
 #include "badgecontainer.h"
 #include "settingsmanager.h"
 
-BadgeContainer *BadgeContainer::instance = 0;
-BadgeContainer *BadgeContainer::getInstance()
-{
-    if (!instance)
-        instance = new BadgeContainer();
-    return instance;
-}
-
 BadgeContainer::BadgeContainer() : netman(NetworkManager::getInstance())
 {
     connect(netman, &NetworkManager::getEmoteSetsOperationFinished, this, &BadgeContainer::onEmoteSetsUpdated);
@@ -21,6 +13,12 @@ BadgeContainer::BadgeContainer() : netman(NetworkManager::getInstance())
 
     connect(netman, &NetworkManager::getGlobalBttvEmotesOperationFinished, this, &BadgeContainer::innerGlobalBttvEmotesLoaded);
     connect(netman, &NetworkManager::getChannelBttvEmotesOperationFinished, this, &BadgeContainer::innerChannelBttvEmotesLoaded);
+}
+
+BadgeContainer *BadgeContainer::getInstance()
+{
+    static BadgeContainer *instance = new BadgeContainer();
+    return instance;
 }
 
 bool BadgeContainer::getChannelBadgeUrl(const QString channelId, const QString badgeName, const QString imageFormat, QString &outUrl) const {

--- a/src/model/channelmanager.cpp
+++ b/src/model/channelmanager.cpp
@@ -15,8 +15,6 @@
 #include "channelmanager.h"
 #include <QCoreApplication>
 
-ChannelManager *ChannelManager::instance = 0;
-
 ChannelManager::ChannelManager() :
     netman(NetworkManager::getInstance()),
     settingsManager(SettingsManager::getInstance())
@@ -63,8 +61,7 @@ ChannelManager::ChannelManager() :
 }
 
 ChannelManager *ChannelManager::getInstance() {
-    if (!instance)
-        instance = new ChannelManager();
+    static ChannelManager *instance = new ChannelManager();
     return instance;
 }
 

--- a/src/model/channelmanager.h
+++ b/src/model/channelmanager.h
@@ -56,7 +56,6 @@ class ChannelManager: public QObject
     ChannelListModel *createFollowedChannelsModel();
     bool isAccessTokenAvailable() { return settingsManager->hasAccessToken(); }
 
-    static ChannelManager *instance;
     ChannelManager();
 
 public:

--- a/src/model/imageprovider.cpp
+++ b/src/model/imageprovider.cpp
@@ -26,7 +26,8 @@
 const int ImageProvider::MSEC_PER_DOWNLOAD = 16; // ~ 256kbit/sec for 2k images
 
 ImageProvider::ImageProvider(const QString imageProviderName, const QString extension, const QString cacheDirName) : QObject(),
-    _cacheProvider(this), _imageProviderName(imageProviderName), _extension(extension) {
+    _imageProviderName(imageProviderName), _extension(extension) {
+    _cacheProvider = new CachedImageProvider(this);
 
     activeDownloadCount = 0;
 
@@ -158,7 +159,7 @@ void ImageProvider::loadImageFile(QString emoteKey, QString filename) {
 }
 
 QQmlImageProviderBase * ImageProvider::getQMLImageProvider() {
-    return &_cacheProvider;
+    return _cacheProvider;
 }
 
 bool ImageProvider::downloadsInProgress() const {

--- a/src/model/imageprovider.h
+++ b/src/model/imageprovider.h
@@ -100,7 +100,7 @@ private:
     QNetworkAccessManager _manager;
 
     friend class CachedImageProvider;
-    CachedImageProvider _cacheProvider;
+    CachedImageProvider *_cacheProvider;
 
     QHash<QString, QImage> _imageTable;
     QString _imageProviderName;

--- a/src/model/settingsmanager.cpp
+++ b/src/model/settingsmanager.cpp
@@ -12,8 +12,8 @@ SettingsManager::SettingsManager(QObject *parent) :
 
 SettingsManager *SettingsManager::getInstance()
 {
-    static SettingsManager instance;
-    return &instance;
+    static SettingsManager *instance = new SettingsManager();
+    return instance;
 }
 
 void SettingsManager::load()

--- a/src/model/viewersmodel.cpp
+++ b/src/model/viewersmodel.cpp
@@ -1,10 +1,13 @@
 #include "viewersmodel.h"
 
-ViewersModel *ViewersModel::instance = 0;
-
 ViewersModel::ViewersModel(QObject *parent) : QObject(parent), netman(NetworkManager::getInstance())
 {
     connect(netman, &NetworkManager::chatterListLoadOperationFinished, this, &ViewersModel::processChatterList);
+}
+
+ViewersModel *ViewersModel::getInstance() {
+    static ViewersModel *instance = new ViewersModel();
+    return instance;
 }
 
 void ViewersModel::processChatterList(QMap<QString, QList<QString>> chatters)

--- a/src/model/viewersmodel.h
+++ b/src/model/viewersmodel.h
@@ -16,11 +16,7 @@ class ViewersModel : public QObject
     explicit ViewersModel(QObject *parent = nullptr);
 
 public:
-    static ViewersModel *getInstance() {
-        if (!instance)
-            instance = new ViewersModel();
-        return instance;
-    }
+    static ViewersModel *getInstance();
 
 signals:
     void chatterListLoaded(QVariantMap chatters);

--- a/src/model/vodmanager.cpp
+++ b/src/model/vodmanager.cpp
@@ -41,15 +41,11 @@ VodManager::VodManager(QObject *parent) :
     settings.endArray();
 
     emit modelChanged();
-
-    std::atexit([](){
-       VodManager::getInstance()->saveSettings();
-    });
 }
 
 VodManager *VodManager::getInstance() {
-    static VodManager instance;
-    return &instance;
+    static VodManager *instance = new VodManager();
+    return instance;
 }
 
 VodManager::~VodManager()

--- a/src/network/httpserver.cpp
+++ b/src/network/httpserver.cpp
@@ -1,15 +1,12 @@
 #include "httpserver.h"
 
-HttpServer *HttpServer::instance = 0;
-
 HttpServer::HttpServer(QObject *parent): QObject(parent)
 {
 
 }
 
 HttpServer *HttpServer::getInstance() {
-    if (!instance)
-        instance = new HttpServer();
+    static HttpServer *instance = new HttpServer();
     return instance;
 }
 

--- a/src/network/httpserver.h
+++ b/src/network/httpserver.h
@@ -19,8 +19,6 @@ class HttpServer: public QObject
     bool listenError = false;
     QString m_port;
 
-    static HttpServer *instance;
-
     explicit HttpServer(QObject *parent = 0);
 public:
     static HttpServer *getInstance();

--- a/src/power/power.cpp
+++ b/src/power/power.cpp
@@ -31,8 +31,6 @@
 #include <QtAndroidExtras>
 #endif
 
-Power *Power::instance = 0;
-
 Power::Power() :
     cookie(0)
 {
@@ -41,8 +39,7 @@ Power::Power() :
 
 Power *Power::getInstance()
 {
-    if (!instance)
-        instance = new Power();
+    static Power *instance = new Power();
     return instance;
 }
 

--- a/src/power/power.h
+++ b/src/power/power.h
@@ -14,7 +14,6 @@ class Power: public QObject
 
     Q_PROPERTY(bool screensaver WRITE setScreensaver)
 
-    static Power *instance;
     Power();
 
 public:


### PR DESCRIPTION
In multiple commits between 1.6.6 and 1.6.7, some objects that derive
from QObject were added which do not have their own heap allocation,
but rather are global variables or live inside another object.
However, because ultimately Qt owns those objects and is responsible
for releasing them, they must have their own allocation.
Otherwise, Qt will attempt to call free on an invalid pointer, which
will most likely cause a crash on exit.

This commit should not introduce a leak since the objects are released
by Qt. Additionally, AFAICT the call to `std::atexit()` can be safely
removed, since the settings are already saved at VodManager's
destructor, which happens at application exit.

Fixes: #302

CC @mrgreywater 